### PR TITLE
texstudio with on_arch block

### DIFF
--- a/Casks/t/texstudio.rb
+++ b/Casks/t/texstudio.rb
@@ -1,21 +1,24 @@
 cask "texstudio" do
-  arch arm: "-m1"
-  ext = on_arch_conditional arm: "zip", intel: "dmg"
-  app_suffix = on_arch_conditional arm: "-#{version}-osx-m1", intel: ""
-
   version "4.7.3"
   sha256 arm:   "314da45d6071c4e18643282b25f6df7114bd42964d85b63526ffbfa048d993e7",
          intel: "ce1cd5ab82d907165e232dfc5ccf8329f086e375f4936c6b9da9b0091ddd0674"
 
-  url "https://github.com/texstudio-org/texstudio/releases/download/#{version}/texstudio-#{version}-osx#{arch}.#{ext}",
-      verified: "github.com/texstudio-org/texstudio/"
+  on_arm do
+    url "https://github.com/texstudio-org/texstudio/releases/download/#{version}/texstudio-#{version}-osx-m1.zip",
+        verified: "github.com/texstudio-org/texstudio/"
+    app "texstudio-#{version}-osx-m1.app", target: "texstudio.app"
+  end
+  on_intel do
+    url "https://github.com/texstudio-org/texstudio/releases/download/#{version}/texstudio-#{version}-osx.dmg",
+        verified: "github.com/texstudio-org/texstudio/"
+    app "texstudio.app"
+  end
+
   name "TeXstudio"
   desc "LaTeX editor"
   homepage "https://texstudio.org/"
 
   depends_on macos: ">= :big_sur"
-
-  app "texstudio#{app_suffix}.app"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/texstudio.sfl*",


### PR DESCRIPTION
From the suggestion, I use the on_arch block to determine the URL.
And I renamed the app name on arm to be the same as the intel arch since an app named with the version number and architecture type is a bit weird.


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
